### PR TITLE
Rebase (NPM version update 2.1.3 -> 2.1.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@
 # Project Intro
 Simple UI modal to introduce a project.
 
-Check out a live demo [here](https://printersdiscovery.chema22r.com/).
+Check out a live demo [here](https://3dpreviewer.chema22r.com/).
+
+![Screenshot](https://i.postimg.cc/435D6GXP/Screen-Shot-2020-03-24-at-16-18-48.png)
 
 ## Setup and Run
 1. Download the source code

--- a/package-lock.json
+++ b/package-lock.json
@@ -985,12 +985,6 @@
                 }
             }
         },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "dev": true
-        },
         "collection-visit": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
@@ -1796,9 +1790,9 @@
             "dev": true
         },
         "eventemitter3": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-            "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.4.tgz",
+            "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ==",
             "dev": true
         },
         "events": {
@@ -2170,9 +2164,9 @@
             }
         },
         "follow-redirects": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.10.0.tgz",
-            "integrity": "sha512-4eyLK6s6lH32nOvLLwlIOnr9zrL8Sm+OvW4pVTJNoXeGzYIkHVf+pADQi+OJ0E67hiuSLezPVPyBcIZO50TmmQ==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.11.0.tgz",
+            "integrity": "sha512-KZm0V+ll8PfBrKwMzdo5D13b1bur9Iq9Zd/RMmAoQQcl2PxxFml8cxXPaaPYVbV0RjNjq1CU7zIzAOqtUPudmA==",
             "dev": true,
             "requires": {
                 "debug": "^3.0.0"
@@ -2990,9 +2984,9 @@
             "dev": true
         },
         "handle-thing": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.0.tgz",
-            "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
+            "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
             "dev": true
         },
         "has": {
@@ -3139,9 +3133,9 @@
             }
         },
         "html-entities": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
-            "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.3.1.tgz",
+            "integrity": "sha512-rhE/4Z3hIhzHAUKbW8jVcCyuT5oJCXXqhN/6mXXVCpzTmvJnoH2HL/bt3EZ6p55jbFJBeAe1ZNpL5BugLujxNA==",
             "dev": true
         },
         "html-minifier-terser": {
@@ -3222,16 +3216,10 @@
                 }
             }
         },
-        "http-parser-js": {
-            "version": "0.4.10",
-            "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
-            "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
-            "dev": true
-        },
         "http-proxy": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.0.tgz",
-            "integrity": "sha512-84I2iJM/n1d4Hdgc6y2+qY5mDaz2PUVjlg9znE9byl+q0uC3DeByqBGReQu5tpLK0TAqTIXScRUV+dg7+bUPpQ==",
+            "version": "1.18.1",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+            "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
             "dev": true,
             "requires": {
                 "eventemitter3": "^4.0.0",
@@ -3691,9 +3679,9 @@
             "dev": true
         },
         "loglevel": {
-            "version": "1.6.7",
-            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.7.tgz",
-            "integrity": "sha512-cY2eLFrQSAfVPhCgH1s7JI73tMbg9YC3v3+ZHVW67sBS7UxWzNEk/ZBbSfLykBWHp33dqqtOv82gjhKEi81T/A==",
+            "version": "1.6.8",
+            "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.8.tgz",
+            "integrity": "sha512-bsU7+gc9AJ2SqpzxwU3+1fedl8zAntbtC5XYlt3s2j1hJcn2PsXSmgN8TaLG/J1/2mod4+cE/3vNL70/c1RNCA==",
             "dev": true
         },
         "lower-case": {
@@ -3868,18 +3856,18 @@
             "dev": true
         },
         "mime-db": {
-            "version": "1.43.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-            "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+            "version": "1.44.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+            "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.26",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-            "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+            "version": "2.1.27",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+            "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
             "dev": true,
             "requires": {
-                "mime-db": "1.43.0"
+                "mime-db": "1.44.0"
             }
         },
         "mimic-fn": {
@@ -4162,12 +4150,6 @@
                 "boolbase": "~1.0.0"
             }
         },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-            "dev": true
-        },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4212,10 +4194,14 @@
             "dev": true
         },
         "object-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
-            "integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ==",
-            "dev": true
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
+            "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+            "dev": true,
+            "requires": {
+                "define-properties": "^1.1.3",
+                "es-abstract": "^1.17.5"
+            }
         },
         "object-keys": {
             "version": "1.1.1",
@@ -4572,9 +4558,9 @@
             }
         },
         "portfinder": {
-            "version": "1.0.25",
-            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.25.tgz",
-            "integrity": "sha512-6ElJnHBbxVA1XSLgBp7G1FiCkQdlqGzuF7DswL5tcea+E8UpuvPU7beVAjjRwCioTS9ZluNbu+ZyRvgTsmqEBg==",
+            "version": "1.0.26",
+            "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.26.tgz",
+            "integrity": "sha512-Xi7mKxJHHMI3rIUrnm/jjUgwhbYMkp/XKEcZX3aG4BrumLpq3nmoQMX+ClYnDZnZ/New7IatC1no5RX0zo1vXQ==",
             "dev": true,
             "requires": {
                 "async": "^2.6.2",
@@ -5379,13 +5365,14 @@
             }
         },
         "sockjs": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.19.tgz",
-            "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/sockjs/-/sockjs-0.3.20.tgz",
+            "integrity": "sha512-SpmVOVpdq0DJc0qArhF3E5xsxvaiqGNb73XfgBpK1y3UD5gs8DSo8aCTsuT5pX8rssdc2NDIzANwP9eCAiSdTA==",
             "dev": true,
             "requires": {
                 "faye-websocket": "^0.10.0",
-                "uuid": "^3.0.1"
+                "uuid": "^3.4.0",
+                "websocket-driver": "0.6.5"
             }
         },
         "sockjs-client": {
@@ -5470,9 +5457,9 @@
             "dev": true
         },
         "spdy": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.1.tgz",
-            "integrity": "sha512-HeZS3PBdMA+sZSu0qwpCxl3DeALD5ASx8pAX0jZdKXSpPWbQ6SYGnlg3BBmYLx5LtiZrmkAZfErCm2oECBcioA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/spdy/-/spdy-4.0.2.tgz",
+            "integrity": "sha512-r46gZQZQV+Kl9oItvl1JZZqJKGr+oEkB08A6BzkiR7593/7IbtuncXHd2YoYeTsG4157ZssMu9KYvUHLcjcDoA==",
             "dev": true,
             "requires": {
                 "debug": "^4.1.0",
@@ -6279,17 +6266,17 @@
             },
             "dependencies": {
                 "mime": {
-                    "version": "2.4.4",
-                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
-                    "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
+                    "version": "2.4.6",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+                    "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
                     "dev": true
                 }
             }
         },
         "webpack-dev-server": {
-            "version": "3.10.3",
-            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.10.3.tgz",
-            "integrity": "sha512-e4nWev8YzEVNdOMcNzNeCN947sWJNd43E5XvsJzbAL08kGc2frm1tQ32hTJslRS+H65LCb/AaUCYU7fjHCpDeQ==",
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz",
+            "integrity": "sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==",
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",
@@ -6300,61 +6287,33 @@
                 "debug": "^4.1.1",
                 "del": "^4.1.1",
                 "express": "^4.17.1",
-                "html-entities": "^1.2.1",
+                "html-entities": "^1.3.1",
                 "http-proxy-middleware": "0.19.1",
                 "import-local": "^2.0.0",
                 "internal-ip": "^4.3.0",
                 "ip": "^1.1.5",
                 "is-absolute-url": "^3.0.3",
                 "killable": "^1.0.1",
-                "loglevel": "^1.6.6",
+                "loglevel": "^1.6.8",
                 "opn": "^5.5.0",
                 "p-retry": "^3.0.1",
-                "portfinder": "^1.0.25",
+                "portfinder": "^1.0.26",
                 "schema-utils": "^1.0.0",
                 "selfsigned": "^1.10.7",
                 "semver": "^6.3.0",
                 "serve-index": "^1.9.1",
-                "sockjs": "0.3.19",
+                "sockjs": "0.3.20",
                 "sockjs-client": "1.4.0",
-                "spdy": "^4.0.1",
+                "spdy": "^4.0.2",
                 "strip-ansi": "^3.0.1",
                 "supports-color": "^6.1.0",
                 "url": "^0.11.0",
                 "webpack-dev-middleware": "^3.7.2",
                 "webpack-log": "^2.0.0",
                 "ws": "^6.2.1",
-                "yargs": "12.0.5"
+                "yargs": "^13.3.2"
             },
             "dependencies": {
-                "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-                    "dev": true
-                },
-                "cliui": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-                    "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^2.1.1",
-                        "strip-ansi": "^4.0.0",
-                        "wrap-ansi": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "strip-ansi": {
-                            "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "^3.0.0"
-                            }
-                        }
-                    }
-                },
                 "debug": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -6364,22 +6323,10 @@
                         "ms": "^2.1.1"
                     }
                 },
-                "get-caller-file": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-                    "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
-                    "dev": true
-                },
                 "ms": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
                     "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-                    "dev": true
-                },
-                "require-main-filename": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-                    "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
                     "dev": true
                 },
                 "schema-utils": {
@@ -6399,87 +6346,22 @@
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
                     "dev": true
                 },
-                "string-width": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-                    "dev": true,
-                    "requires": {
-                        "is-fullwidth-code-point": "^2.0.0",
-                        "strip-ansi": "^4.0.0"
-                    },
-                    "dependencies": {
-                        "strip-ansi": {
-                            "version": "4.0.0",
-                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-                            "dev": true,
-                            "requires": {
-                                "ansi-regex": "^3.0.0"
-                            }
-                        }
-                    }
-                },
-                "wrap-ansi": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
-                    "dev": true,
-                    "requires": {
-                        "string-width": "^1.0.1",
-                        "strip-ansi": "^3.0.1"
-                    },
-                    "dependencies": {
-                        "is-fullwidth-code-point": {
-                            "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                            "dev": true,
-                            "requires": {
-                                "number-is-nan": "^1.0.0"
-                            }
-                        },
-                        "string-width": {
-                            "version": "1.0.2",
-                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                            "dev": true,
-                            "requires": {
-                                "code-point-at": "^1.0.0",
-                                "is-fullwidth-code-point": "^1.0.0",
-                                "strip-ansi": "^3.0.0"
-                            }
-                        }
-                    }
-                },
                 "yargs": {
-                    "version": "12.0.5",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-                    "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+                    "version": "13.3.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+                    "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
                     "dev": true,
                     "requires": {
-                        "cliui": "^4.0.0",
-                        "decamelize": "^1.2.0",
+                        "cliui": "^5.0.0",
                         "find-up": "^3.0.0",
-                        "get-caller-file": "^1.0.1",
-                        "os-locale": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
                         "require-directory": "^2.1.1",
-                        "require-main-filename": "^1.0.1",
+                        "require-main-filename": "^2.0.0",
                         "set-blocking": "^2.0.0",
-                        "string-width": "^2.0.0",
+                        "string-width": "^3.0.0",
                         "which-module": "^2.0.0",
-                        "y18n": "^3.2.1 || ^4.0.0",
-                        "yargs-parser": "^11.1.1"
-                    }
-                },
-                "yargs-parser": {
-                    "version": "11.1.1",
-                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-                    "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-                    "dev": true,
-                    "requires": {
-                        "camelcase": "^5.0.0",
-                        "decamelize": "^1.2.0"
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.2"
                     }
                 }
             }
@@ -6514,20 +6396,18 @@
             }
         },
         "websocket-driver": {
-            "version": "0.7.3",
-            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
-            "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+            "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
             "dev": true,
             "requires": {
-                "http-parser-js": ">=0.4.0 <0.4.11",
-                "safe-buffer": ">=5.1.0",
                 "websocket-extensions": ">=0.1.1"
             }
         },
         "websocket-extensions": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-            "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+            "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
             "dev": true
         },
         "which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "project-intro",
-    "version": "2.1.3",
+    "version": "2.1.4",
     "description": "Simple UI modal to introduce a project",
     "main": "dist/project-intro.js",
     "scripts": {
@@ -33,7 +33,7 @@
         "style-loader": "^1.1.3",
         "webpack": "^4.42.1",
         "webpack-cli": "^3.3.11",
-        "webpack-dev-server": "^3.10.3",
+        "webpack-dev-server": "^3.11.0",
         "webpack-merge": "^4.2.2"
     }
 }


### PR DESCRIPTION
* README.md modified

* [Security] Bump websocket-extensions from 0.1.3 to 0.1.4 (#30)

Bumps [websocket-extensions](https://github.com/faye/websocket-extensions-node) from 0.1.3 to 0.1.4. **This update includes a security fix.**
- [Release notes](https://github.com/faye/websocket-extensions-node/releases)
- [Changelog](https://github.com/faye/websocket-extensions-node/blob/master/CHANGELOG.md)
- [Commits](https://github.com/faye/websocket-extensions-node/compare/0.1.3...0.1.4)

Signed-off-by: dependabot-preview[bot] <support@dependabot.com>

Co-authored-by: dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>

* security fix

* version upgrade 2.1.3  -> 2.1.4

Co-authored-by: dependabot-preview[bot] <27856297+dependabot-preview[bot]@users.noreply.github.com>